### PR TITLE
Fix URL: std/colors/* to std/fmt/colors.ts

### DIFF
--- a/matchers.ts
+++ b/matchers.ts
@@ -14,7 +14,7 @@ import {
   white,
   gray,
   bold
-} from "https://deno.land/std/colors/mod.ts";
+} from "https://deno.land/std/fmt/colors.ts";
 
 import * as mock from "./mock.ts";
 


### PR DESCRIPTION
Fixed an error due to URL change

> error: Uncaught Other: Import 'https://deno.land/std/colors/mod.ts' failed: 404 Not Found
> ► $deno$/dispatch_json.ts:40:11
>    at DenoError ($deno$/errors.ts:20:5)
>    at unwrapResponse ($deno$/dispatch_json.ts:40:11)
>    at sendAsync ($deno$/dispatch_json.ts:91:10)

moved std/colors/* to std/fmt/colors.ts
