### PR TITLE
Update to std@v0.50.0 and fix tests

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -1,7 +1,7 @@
 import * as builtInMatchers from "./matchers.ts";
 import { Matcher, Matchers } from "./matchers.ts";
 
-import { AssertionError } from "https://deno.land/std@v0.41.0/testing/asserts.ts";
+import { AssertionError } from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 
 interface Expected {
   toBe(candidate: any): void;

--- a/expect_test.ts
+++ b/expect_test.ts
@@ -2,7 +2,7 @@ import {
   assertEquals,
   assertThrows,
   AssertionError,
-} from "https://deno.land/std@v0.41.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 
 import { expect, addMatchers } from "./expect.ts";
 import * as mock from "./mock.ts";
@@ -43,597 +43,700 @@ async function assertAllFail(...fns: Function[]) {
   }
 }
 
-Deno.test(function exportsFunction() {
-  assertEquals(typeof expect, "function");
+Deno.test({
+  name: "exportsFunction",
+  fn: () => {
+    assertEquals(typeof expect, "function");
+  },
 });
 
-Deno.test(function throwsWhenNoMatcherFound() {
-  assertThrows(
-    //@ts-ignore
-    () => expect(true).toBeFancy(),
-    TypeError,
-    "matcher not found: toBeFancy",
-  );
+Deno.test({
+  name: "throwsWhenNoMatcherFound",
+  fn: () => {
+    assertThrows(
+      //@ts-ignore
+      () => expect(true).toBeFancy(),
+      TypeError,
+      "matcher not found: toBeFancy",
+    );
+  },
 });
 
-Deno.test(function allowsExtendingMatchers() {
-  addMatchers({
-    toBeFancy(value: any) {
-      if (value === "fancy") {
-        return { pass: true };
-      } else {
-        return { pass: false, message: "was not fancy" };
-      }
-    },
-  });
+Deno.test({
+  name: "allowsExtendingMatchers",
+  fn: () => {
+    addMatchers({
+      toBeFancy(value: any) {
+        if (value === "fancy") {
+          return { pass: true };
+        } else {
+          return { pass: false, message: "was not fancy" };
+        }
+      },
+    });
 
-  // @ts-ignore
-  assertPass(() => expect("fancy").toBeFancy());
+    // @ts-ignore
+    assertPass(() => expect("fancy").toBeFancy());
+  },
 });
 
-Deno.test(async function toBe() {
-  const obj = {};
-  assertEquals(typeof expect(obj).toBe, "function");
-  await assertAllPass(
-    () => expect(obj).toBe(obj),
-    () => expect(obj).not.toBe({}),
-    () => expect(Promise.resolve(1)).resolves.toBe(1),
-    () => expect(Promise.reject(1)).rejects.toBe(1),
-  );
+Deno.test({
+  name: "toBe",
+  fn: async () => {
+    const obj = {};
+    assertEquals(typeof expect(obj).toBe, "function");
+    await assertAllPass(
+      () => expect(obj).toBe(obj),
+      () => expect(obj).not.toBe({}),
+      () => expect(Promise.resolve(1)).resolves.toBe(1),
+      () => expect(Promise.reject(1)).rejects.toBe(1),
+    );
 
-  await assertFail(() => expect(obj).toBe({}));
-  await assertFail(() => expect(obj).not.toBe(obj));
+    await assertFail(() => expect(obj).toBe({}));
+    await assertFail(() => expect(obj).not.toBe(obj));
+  },
 });
 
-Deno.test(async function toEqual() {
-  const obj = {};
+Deno.test({
+  name: "toEqual",
+  fn: async () => {
+    const obj = {};
 
-  await assertAllPass(
-    () => expect(1).toEqual(1),
-    () => expect(obj).toEqual({}),
-    () => expect(obj).toEqual(obj),
-    () => expect({ a: 1 }).toEqual({ a: 1 }),
-    () => expect([1]).toEqual([1]),
-    () => expect(Promise.resolve(1)).resolves.toEqual(1),
-    () => expect(Promise.reject(1)).rejects.toEqual(1),
-  );
+    await assertAllPass(
+      () => expect(1).toEqual(1),
+      () => expect(obj).toEqual({}),
+      () => expect(obj).toEqual(obj),
+      () => expect({ a: 1 }).toEqual({ a: 1 }),
+      () => expect([1]).toEqual([1]),
+      () => expect(Promise.resolve(1)).resolves.toEqual(1),
+      () => expect(Promise.reject(1)).rejects.toEqual(1),
+    );
 
-  await assertAllFail(
-    () => expect(1).toEqual(2),
-    () => expect(1).toEqual(true),
-    () => expect({}).toEqual(true),
-    () => expect(1).not.toEqual(1),
-    () => expect(true).not.toEqual(true),
-  );
+    await assertAllFail(
+      () => expect(1).toEqual(2),
+      () => expect(1).toEqual(true),
+      () => expect({}).toEqual(true),
+      () => expect(1).not.toEqual(1),
+      () => expect(true).not.toEqual(true),
+    );
+  },
 });
 
-Deno.test(async function resolves() {
-  const resolves = expect(Promise.resolve(true)).resolves;
-  for (let method of ["toEqual", "toBe", "toBeTruthy", "toBeFalsy"]) {
-    assertEquals(typeof (resolves as any)[method], "function", `missing ${method}`);
-  }
+Deno.test({
+  name: "resolves",
+  fn: async () => {
+    const resolves = expect(Promise.resolve(true)).resolves;
+    for (let method of ["toEqual", "toBe", "toBeTruthy", "toBeFalsy"]) {
+      assertEquals(
+        typeof (resolves as any)[method],
+        "function",
+        `missing ${method}`,
+      );
+    }
+  },
 });
 
-Deno.test(async function rejects() {
-  const rejects = expect(Promise.reject(true)).rejects;
-  for (
-    let method of ["toEqual", "toBe", "toBeTruthy", "toBeFalsy"]
-  ) {
-    assertEquals(typeof (rejects as any)[method], "function");
-  }
+Deno.test({
+  name: "rejects",
+  fn: async () => {
+    const rejects = expect(Promise.reject(true)).rejects;
+    for (
+      let method of ["toEqual", "toBe", "toBeTruthy", "toBeFalsy"]
+    ) {
+      assertEquals(typeof (rejects as any)[method], "function");
+    }
+  },
 });
 
-Deno.test(async function toBeDefined() {
-  await assertAllPass(
-    () => expect(true).toBeDefined(),
-    () => expect({}).toBeDefined(),
-    () => expect([]).toBeDefined(),
-    () => expect(undefined).not.toBeDefined(),
-    () => expect(Promise.resolve({})).resolves.toBeDefined(),
-    () => expect(Promise.reject({})).rejects.toBeDefined(),
-  );
+Deno.test({
+  name: "toBeDefined",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(true).toBeDefined(),
+      () => expect({}).toBeDefined(),
+      () => expect([]).toBeDefined(),
+      () => expect(undefined).not.toBeDefined(),
+      () => expect(Promise.resolve({})).resolves.toBeDefined(),
+      () => expect(Promise.reject({})).rejects.toBeDefined(),
+    );
 
-  await assertAllFail(
-    () => expect(undefined).toBeDefined(),
-    () => expect(true).not.toBeDefined(),
-  );
+    await assertAllFail(
+      () => expect(undefined).toBeDefined(),
+      () => expect(true).not.toBeDefined(),
+    );
+  },
 });
 
-Deno.test(async function toBeUndefined() {
-  await assertAllPass(
-    () => expect(undefined).toBeUndefined(),
-    () => expect(null).not.toBeUndefined(),
-    () => expect(Promise.resolve(undefined)).resolves.toBeUndefined(),
-    () => expect(Promise.reject(undefined)).rejects.toBeUndefined(),
-  );
+Deno.test({
+  name: "toBeUndefined",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(undefined).toBeUndefined(),
+      () => expect(null).not.toBeUndefined(),
+      () => expect(Promise.resolve(undefined)).resolves.toBeUndefined(),
+      () => expect(Promise.reject(undefined)).rejects.toBeUndefined(),
+    );
 
-  await assertAllFail(
-    () => expect(null).toBeUndefined(),
-    () => expect(undefined).not.toBeUndefined(),
-    () => expect(false).toBeUndefined(),
-  );
+    await assertAllFail(
+      () => expect(null).toBeUndefined(),
+      () => expect(undefined).not.toBeUndefined(),
+      () => expect(false).toBeUndefined(),
+    );
+  },
 });
 
-Deno.test(async function toBeTruthy() {
-  await assertAllPass(
-    () => expect(true).toBeTruthy(),
-    () => expect(false).not.toBeTruthy(),
-    () => expect(Promise.resolve(true)).resolves.toBeTruthy(),
-    () => expect(Promise.reject(true)).rejects.toBeTruthy(),
-  );
+Deno.test({
+  name: "toBeTruthy",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(true).toBeTruthy(),
+      () => expect(false).not.toBeTruthy(),
+      () => expect(Promise.resolve(true)).resolves.toBeTruthy(),
+      () => expect(Promise.reject(true)).rejects.toBeTruthy(),
+    );
 
-  await assertAllFail(
-    () => expect(false).toBeTruthy(),
-    () => expect(true).not.toBeTruthy(),
-  );
+    await assertAllFail(
+      () => expect(false).toBeTruthy(),
+      () => expect(true).not.toBeTruthy(),
+    );
+  },
 });
 
-Deno.test(async function toBeFalsy() {
-  await assertAllPass(
-    () => expect(false).toBeFalsy(),
-    () => expect(true).not.toBeFalsy(),
-    () => expect(Promise.resolve(false)).resolves.toBeFalsy(),
-    () => expect(Promise.reject(false)).rejects.toBeFalsy(),
-  );
-  await assertAllFail(
-    () => expect(true).toBeFalsy(),
-    () => expect(false).not.toBeFalsy(),
-  );
+Deno.test({
+  name: "toBeFalsy",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(false).toBeFalsy(),
+      () => expect(true).not.toBeFalsy(),
+      () => expect(Promise.resolve(false)).resolves.toBeFalsy(),
+      () => expect(Promise.reject(false)).rejects.toBeFalsy(),
+    );
+    await assertAllFail(
+      () => expect(true).toBeFalsy(),
+      () => expect(false).not.toBeFalsy(),
+    );
+  },
 });
 
-Deno.test(async function toBeGreaterThan() {
-  await assertAllPass(
-    () => expect(2).toBeGreaterThan(1),
-    () => expect(1).not.toBeGreaterThan(2),
-    () => expect(Promise.resolve(2)).resolves.toBeGreaterThan(1),
-    () => expect(Promise.reject(2)).rejects.toBeGreaterThan(1),
-  );
+Deno.test({
+  name: "toBeGreaterThan",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(2).toBeGreaterThan(1),
+      () => expect(1).not.toBeGreaterThan(2),
+      () => expect(Promise.resolve(2)).resolves.toBeGreaterThan(1),
+      () => expect(Promise.reject(2)).rejects.toBeGreaterThan(1),
+    );
 
-  await assertAllFail(
-    () => expect(1).toBeGreaterThan(1),
-    () => expect(1).toBeGreaterThan(2),
-    () => expect(2).not.toBeGreaterThan(1),
-  );
+    await assertAllFail(
+      () => expect(1).toBeGreaterThan(1),
+      () => expect(1).toBeGreaterThan(2),
+      () => expect(2).not.toBeGreaterThan(1),
+    );
+  },
 });
 
-Deno.test(async function toBeLessThan() {
-  await assertAllPass(
-    () => expect(1).toBeLessThan(2),
-    () => expect(2).not.toBeLessThan(1),
-    () => expect(Promise.resolve(1)).resolves.toBeLessThan(2),
-    () => expect(Promise.reject(1)).rejects.toBeLessThan(2),
-  );
+Deno.test({
+  name: "toBeLessThan",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(1).toBeLessThan(2),
+      () => expect(2).not.toBeLessThan(1),
+      () => expect(Promise.resolve(1)).resolves.toBeLessThan(2),
+      () => expect(Promise.reject(1)).rejects.toBeLessThan(2),
+    );
 
-  await assertAllFail(
-    () => expect(1).toBeLessThan(1),
-    () => expect(2).toBeLessThan(1),
-    () => expect(1).not.toBeLessThan(2),
-  );
+    await assertAllFail(
+      () => expect(1).toBeLessThan(1),
+      () => expect(2).toBeLessThan(1),
+      () => expect(1).not.toBeLessThan(2),
+    );
+  },
 });
 
-Deno.test(async function toBeGreaterThanOrEqual() {
-  await assertAllPass(
-    () => expect(2).toBeGreaterThanOrEqual(1),
-    () => expect(1).toBeGreaterThanOrEqual(1),
-    () => expect(1).not.toBeGreaterThanOrEqual(2),
-    () => expect(Promise.resolve(2)).resolves.toBeGreaterThanOrEqual(2),
-    () => expect(Promise.reject(2)).rejects.toBeGreaterThanOrEqual(2),
-  );
+Deno.test({
+  name: "toBeGreaterThanOrEqual",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(2).toBeGreaterThanOrEqual(1),
+      () => expect(1).toBeGreaterThanOrEqual(1),
+      () => expect(1).not.toBeGreaterThanOrEqual(2),
+      () => expect(Promise.resolve(2)).resolves.toBeGreaterThanOrEqual(2),
+      () => expect(Promise.reject(2)).rejects.toBeGreaterThanOrEqual(2),
+    );
 
-  await assertAllFail(
-    () => expect(1).toBeGreaterThanOrEqual(2),
-    () => expect(2).not.toBeGreaterThanOrEqual(1),
-  );
+    await assertAllFail(
+      () => expect(1).toBeGreaterThanOrEqual(2),
+      () => expect(2).not.toBeGreaterThanOrEqual(1),
+    );
+  },
 });
 
-Deno.test(async function toBeLessThanOrEqual() {
-  await assertAllPass(
-    () => expect(1).toBeLessThanOrEqual(2),
-    () => expect(1).toBeLessThanOrEqual(1),
-    () => expect(2).not.toBeLessThanOrEqual(1),
-    () => expect(Promise.resolve(1)).resolves.toBeLessThanOrEqual(2),
-    () => expect(Promise.reject(1)).rejects.toBeLessThanOrEqual(2),
-  );
-  await assertAllFail(
-    () => expect(2).toBeLessThanOrEqual(1),
-    () => expect(1).not.toBeLessThanOrEqual(1),
-    () => expect(1).not.toBeLessThanOrEqual(2),
-  );
+Deno.test({
+  name: "toBeLessThanOrEqual",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(1).toBeLessThanOrEqual(2),
+      () => expect(1).toBeLessThanOrEqual(1),
+      () => expect(2).not.toBeLessThanOrEqual(1),
+      () => expect(Promise.resolve(1)).resolves.toBeLessThanOrEqual(2),
+      () => expect(Promise.reject(1)).rejects.toBeLessThanOrEqual(2),
+    );
+    await assertAllFail(
+      () => expect(2).toBeLessThanOrEqual(1),
+      () => expect(1).not.toBeLessThanOrEqual(1),
+      () => expect(1).not.toBeLessThanOrEqual(2),
+    );
+  },
 });
 
-Deno.test(async function toBeNull() {
-  await assertAllPass(
-    () => expect(null).toBeNull(),
-    () => expect(undefined).not.toBeNull(),
-    () => expect(false).not.toBeNull(),
-    () => expect(Promise.resolve(null)).resolves.toBeNull(),
-    () => expect(Promise.reject(null)).rejects.toBeNull(),
-  );
+Deno.test({
+  name: "toBeNull",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(null).toBeNull(),
+      () => expect(undefined).not.toBeNull(),
+      () => expect(false).not.toBeNull(),
+      () => expect(Promise.resolve(null)).resolves.toBeNull(),
+      () => expect(Promise.reject(null)).rejects.toBeNull(),
+    );
 
-  await assertAllFail(
-    () => expect({}).toBeNull(),
-    () => expect(null).not.toBeNull(),
-    () => expect(undefined).toBeNull(),
-  );
+    await assertAllFail(
+      () => expect({}).toBeNull(),
+      () => expect(null).not.toBeNull(),
+      () => expect(undefined).toBeNull(),
+    );
+  },
 });
 
-Deno.test(async function toBeInstanceOf() {
-  class A {}
-  class B {}
+Deno.test({
+  name: "toBeInstanceOf",
+  fn: async () => {
+    class A {}
+    class B {}
 
-  await assertAllPass(
-    () => expect(new A()).toBeInstanceOf(A),
-    () => expect(new A()).not.toBeInstanceOf(B),
-  );
+    await assertAllPass(
+      () => expect(new A()).toBeInstanceOf(A),
+      () => expect(new A()).not.toBeInstanceOf(B),
+    );
 
-  await assertAllFail(
-    () => expect({}).toBeInstanceOf(A),
-    () => expect(null).toBeInstanceOf(A),
-  );
+    await assertAllFail(
+      () => expect({}).toBeInstanceOf(A),
+      () => expect(null).toBeInstanceOf(A),
+    );
+  },
 });
 
-Deno.test(async function toBeNaN() {
-  await assertAllPass(
-    () => expect(NaN).toBeNaN(),
-    () => expect(10).not.toBeNaN(),
-    () => expect(Promise.resolve(NaN)).resolves.toBeNaN(),
-  );
+Deno.test({
+  name: "toBeNaN",
+  fn: async () => {
+    await assertAllPass(
+      () => expect(NaN).toBeNaN(),
+      () => expect(10).not.toBeNaN(),
+      () => expect(Promise.resolve(NaN)).resolves.toBeNaN(),
+    );
 
-  await assertAllFail(() => expect(10).toBeNaN(), () => expect(10).toBeNaN());
+    await assertAllFail(() => expect(10).toBeNaN(), () => expect(10).toBeNaN());
+  },
 });
 
-Deno.test(async function toBeMatch() {
-  await assertAllPass(
-    () => expect("hello").toMatch(/^hell/),
-    () => expect("hello").toMatch("hello"),
-    () => expect("hello").toMatch("hell"),
-  );
+Deno.test({
+  name: "toBeMatch",
+  fn: async () => {
+    await assertAllPass(
+      () => expect("hello").toMatch(/^hell/),
+      () => expect("hello").toMatch("hello"),
+      () => expect("hello").toMatch("hell"),
+    );
 
-  await assertAllFail(() => expect("yo").toMatch(/^hell/));
+    await assertAllFail(() => expect("yo").toMatch(/^hell/));
+  },
 });
 
-Deno.test(async function toHaveProperty() {
-  await assertAllPass(() => expect({ a: "10" }).toHaveProperty("a"));
+Deno.test({
+  name: "toHaveProperty",
+  fn: async () => {
+    await assertAllPass(() => expect({ a: "10" }).toHaveProperty("a"));
 
-  await assertAllFail(() => expect({ a: 1 }).toHaveProperty("b"));
+    await assertAllFail(() => expect({ a: 1 }).toHaveProperty("b"));
+  },
 });
 
-Deno.test(async function toHaveLength() {
-  await assertAllPass(
-    () => expect([1, 2]).toHaveLength(2),
-    () => expect({ length: 10 }).toHaveLength(10),
-  );
+Deno.test({
+  name: "toHaveLength",
+  fn: async () => {
+    await assertAllPass(
+      () => expect([1, 2]).toHaveLength(2),
+      () => expect({ length: 10 }).toHaveLength(10),
+    );
 
-  await assertAllFail(() => expect([]).toHaveLength(10));
+    await assertAllFail(() => expect([]).toHaveLength(10));
+  },
 });
 
-Deno.test(async function toContain() {
-  await assertAllPass(
-    () => expect([1, 2, 3]).toContain(2),
-    () => expect([]).not.toContain(2),
-  );
+Deno.test({
+  name: "toContain",
+  fn: async () => {
+    await assertAllPass(
+      () => expect([1, 2, 3]).toContain(2),
+      () => expect([]).not.toContain(2),
+    );
 
-  await assertAllFail(
-    () => expect([1, 2, 3]).toContain(4),
-    () => expect([]).toContain(4),
-  );
+    await assertAllFail(
+      () => expect([1, 2, 3]).toContain(4),
+      () => expect([]).toContain(4),
+    );
+  },
 });
 
-Deno.test(async function toThrow() {
-  await assertAllPass(
-    () =>
-      expect(() => {
-        throw new Error("TEST");
-      }).toThrow("TEST"),
-    () => expect(Promise.reject(new Error("TEST"))).rejects.toThrow("TEST"),
-  );
+Deno.test({
+  name: "toThrow",
+  fn: async () => {
+    await assertAllPass(
+      () =>
+        expect(() => {
+          throw new Error("TEST");
+        }).toThrow("TEST"),
+      () => expect(Promise.reject(new Error("TEST"))).rejects.toThrow("TEST"),
+    );
 
-  await assertAllFail(() => expect(() => true).toThrow());
+    await assertAllFail(() => expect(() => true).toThrow());
+  },
 });
 
-Deno.test(async function toHaveBeenCalled() {
-  assertAllPass(
-    () => {
+Deno.test({
+  name: "toHaveBeenCalled",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m(10);
+        m(20);
+        expect(m).toHaveBeenCalled();
+      },
+      () => {
+        const m = mock.fn();
+        expect(m).not.toHaveBeenCalled();
+      },
+    );
+
+    await assertAllFail(() => {
       const m = mock.fn();
-      m(10);
-      m(20);
       expect(m).toHaveBeenCalled();
-    },
-    () => {
-      const m = mock.fn();
-      expect(m).not.toHaveBeenCalled();
-    },
-  );
-
-  assertAllFail(() => {
-    const m = mock.fn();
-    expect(m).toHaveBeenCalled();
-  });
+    });
+  },
 });
 
-Deno.test(function toHaveBeenCalledTimes() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveBeenCalledTimes(0);
-    },
-    () => {
-      const m = mock.fn();
-      m();
-      m();
-      expect(m).toHaveBeenCalledTimes(2);
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveBeenCalledTimes(1);
-    },
-    () => {
-      const m = mock.fn();
-      m();
-      m();
-      expect(m).toHaveBeenCalledTimes(3);
-    },
-  );
-});
-
-Deno.test(function toHaveBeenCalledWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      expect(m).toHaveBeenCalledWith(1, 2, 3);
-    },
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      m(2, 3, 4);
-      expect(m).toHaveBeenCalledWith(1, 2, 3);
-      expect(m).toHaveBeenCalledWith(2, 3, 4);
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveBeenCalledWith(1);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).toHaveBeenCalledWith(1);
-    },
-  );
-});
-
-Deno.test(function toHaveBeenLastCalledWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      expect(m).toHaveBeenLastCalledWith(1, 2, 3);
-    },
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      m(2, 3, 4);
-      expect(m).not.toHaveBeenLastCalledWith(1, 2, 3);
-      expect(m).toHaveBeenLastCalledWith(2, 3, 4);
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveBeenLastCalledWith(1);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).toHaveBeenLastCalledWith(1);
-    },
-  );
-});
-
-Deno.test(function toHaveBeenNthCalledWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      expect(m).toHaveBeenNthCalledWith(1, 1, 2, 3);
-    },
-    () => {
-      const m = mock.fn();
-      m(1, 2, 3);
-      m(2, 3, 4);
-      expect(m).not.toHaveBeenNthCalledWith(2, 1, 2, 3);
-      expect(m).toHaveBeenNthCalledWith(2, 2, 3, 4);
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveBeenNthCalledWith(1, 1, 2);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).toHaveBeenNthCalledWith(1, 1);
-    },
-  );
-});
-
-Deno.test(function toHaveReturnedWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m();
-      expect(m).toHaveReturnedWith(undefined);
-    },
-    () => {
-      const m = mock.fn(() => true);
-      m();
-      expect(m).not.toHaveReturnedWith(false);
-      expect(m).toHaveReturnedWith(true);
-    },
-    () => {
-      const m = mock.fn(() => {
-        throw new Error("TEST");
-      });
-      try {
+Deno.test({
+  name: "toHaveBeenCalledTimes",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveBeenCalledTimes(0);
+      },
+      () => {
+        const m = mock.fn();
         m();
-      } catch (err) {}
-      expect(m).not.toHaveReturnedWith(10);
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveReturnedWith(1);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).toHaveReturnedWith(1);
-    },
-  );
-});
-
-Deno.test(function toHaveReturnedTimes() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m();
-      expect(m).toHaveReturnedTimes(1);
-    },
-    () => {
-      const m = mock.fn(() => true);
-      expect(m).toHaveReturnedTimes(0);
-    },
-    () => {
-      const m = mock.fn(() => {
-        throw new Error("TEST");
-      });
-      try {
         m();
-      } catch (err) {}
-      expect(m).toHaveReturnedTimes(0);
-    },
-  );
+        expect(m).toHaveBeenCalledTimes(2);
+      },
+    );
 
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveReturnedTimes(1);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).not.toHaveReturnedTimes(1);
-    },
-  );
-});
-
-Deno.test(function toHaveReturned() {
-  assertAllPass(
-    () => {
-      const m = mock.fn();
-      m();
-      expect(m).toHaveReturned();
-    },
-    () => {
-      const m = mock.fn();
-      expect(m).not.toHaveReturned();
-    },
-    () => {
-      const m = mock.fn(() => {
-        throw new Error("TEST");
-      });
-      try {
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveBeenCalledTimes(1);
+      },
+      () => {
+        const m = mock.fn();
         m();
-      } catch (err) {}
-      expect(m).not.toHaveReturned();
-    },
-  );
-
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveReturned();
-    },
-    () => {
-      const m = mock.fn();
-      m();
-      expect(m).not.toHaveReturned();
-    },
-    () => {
-      const m = mock.fn(() => {
-        throw new Error("TEST");
-      });
-      m();
-      expect(m).not.toHaveReturned();
-    },
-  );
+        m();
+        expect(m).toHaveBeenCalledTimes(3);
+      },
+    );
+  },
 });
 
-Deno.test(function toHaveLastReturnedWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn((x: number) => x);
-      m(1);
-      m(2);
-      expect(m).toHaveLastReturnedWith(2);
-    },
-    () => {
-      const m = mock.fn((x: number) => x);
-      m(1);
-      m(2);
-      expect(m).toHaveLastReturnedWith(2);
-    },
-  );
+Deno.test({
+  name: "toHaveBeenCalledWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        expect(m).toHaveBeenCalledWith(1, 2, 3);
+      },
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        m(2, 3, 4);
+        expect(m).toHaveBeenCalledWith(1, 2, 3);
+        expect(m).toHaveBeenCalledWith(2, 3, 4);
+      },
+    );
 
-  assertAllFail(
-    () => {
-      const m = mock.fn((x: number) => x);
-      expect(m).toHaveLastReturnedWith(1);
-    },
-    () => {
-      const m = mock.fn((x: number) => x);
-      m(2);
-      expect(m).toHaveLastReturnedWith(1);
-    },
-  );
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveBeenCalledWith(1);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).toHaveBeenCalledWith(1);
+      },
+    );
+  },
 });
 
-Deno.test(function toHaveNthReturnedWith() {
-  assertAllPass(
-    () => {
-      const m = mock.fn((x: number) => x);
-      m(1, 2, 3);
-      expect(m).toHaveNthReturnedWith(1, 1);
-    },
-    () => {
-      const m = mock.fn((x: number) => x);
-      m(1, 2, 3);
-      m(2, 3, 4);
-      expect(m).not.toHaveNthReturnedWith(2, 1);
-      expect(m).toHaveNthReturnedWith(2, 2);
-    },
-  );
+Deno.test({
+  name: "toHaveBeenLastCalledWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        expect(m).toHaveBeenLastCalledWith(1, 2, 3);
+      },
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        m(2, 3, 4);
+        expect(m).not.toHaveBeenLastCalledWith(1, 2, 3);
+        expect(m).toHaveBeenLastCalledWith(2, 3, 4);
+      },
+    );
 
-  assertAllFail(
-    () => {
-      const m = mock.fn();
-      expect(m).toHaveNthReturnedWith(1, 1);
-    },
-    () => {
-      const m = mock.fn();
-      m(2);
-      expect(m).toHaveNthReturnedWith(1, 1);
-    },
-  );
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveBeenLastCalledWith(1);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).toHaveBeenLastCalledWith(1);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveBeenNthCalledWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        expect(m).toHaveBeenNthCalledWith(1, 1, 2, 3);
+      },
+      () => {
+        const m = mock.fn();
+        m(1, 2, 3);
+        m(2, 3, 4);
+        expect(m).not.toHaveBeenNthCalledWith(2, 1, 2, 3);
+        expect(m).toHaveBeenNthCalledWith(2, 2, 3, 4);
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveBeenNthCalledWith(1, 1, 2);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).toHaveBeenNthCalledWith(1, 1);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveReturnedWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m();
+        expect(m).toHaveReturnedWith(undefined);
+      },
+      () => {
+        const m = mock.fn(() => true);
+        m();
+        expect(m).not.toHaveReturnedWith(false);
+        expect(m).toHaveReturnedWith(true);
+      },
+      () => {
+        const m = mock.fn(() => {
+          throw new Error("TEST");
+        });
+        try {
+          m();
+        } catch (err) {}
+        expect(m).not.toHaveReturnedWith(10);
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveReturnedWith(1);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).toHaveReturnedWith(1);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveReturnedTimes",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m();
+        expect(m).toHaveReturnedTimes(1);
+      },
+      () => {
+        const m = mock.fn(() => true);
+        expect(m).toHaveReturnedTimes(0);
+      },
+      () => {
+        const m = mock.fn(() => {
+          throw new Error("TEST");
+        });
+        try {
+          m();
+        } catch (err) {}
+        expect(m).toHaveReturnedTimes(0);
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveReturnedTimes(1);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).not.toHaveReturnedTimes(1);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveReturned",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn();
+        m();
+        expect(m).toHaveReturned();
+      },
+      () => {
+        const m = mock.fn();
+        expect(m).not.toHaveReturned();
+      },
+      () => {
+        const m = mock.fn(() => {
+          throw new Error("TEST");
+        });
+        try {
+          m();
+        } catch (err) {}
+        expect(m).not.toHaveReturned();
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveReturned();
+      },
+      () => {
+        const m = mock.fn();
+        m();
+        expect(m).not.toHaveReturned();
+      },
+      () => {
+        const m = mock.fn(() => {
+          throw new Error("TEST");
+        });
+        m();
+        expect(m).not.toHaveReturned();
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveLastReturnedWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn((x: number) => x);
+        m(1);
+        m(2);
+        expect(m).toHaveLastReturnedWith(2);
+      },
+      () => {
+        const m = mock.fn((x: number) => x);
+        m(1);
+        m(2);
+        expect(m).toHaveLastReturnedWith(2);
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn((x: number) => x);
+        expect(m).toHaveLastReturnedWith(1);
+      },
+      () => {
+        const m = mock.fn((x: number) => x);
+        m(2);
+        expect(m).toHaveLastReturnedWith(1);
+      },
+    );
+  },
+});
+
+Deno.test({
+  name: "toHaveNthReturnedWith",
+  fn: async () => {
+    await assertAllPass(
+      () => {
+        const m = mock.fn((x: number) => x);
+        m(1, 2, 3);
+        expect(m).toHaveNthReturnedWith(1, 1);
+      },
+      () => {
+        const m = mock.fn((x: number) => x);
+        m(1, 2, 3);
+        m(2, 3, 4);
+        expect(m).not.toHaveNthReturnedWith(2, 1);
+        expect(m).toHaveNthReturnedWith(2, 2);
+      },
+    );
+
+    await assertAllFail(
+      () => {
+        const m = mock.fn();
+        expect(m).toHaveNthReturnedWith(1, 1);
+      },
+      () => {
+        const m = mock.fn();
+        m(2);
+        expect(m).toHaveNthReturnedWith(1, 1);
+      },
+    );
+  },
 });

--- a/matchers.ts
+++ b/matchers.ts
@@ -1,19 +1,19 @@
 import {
   AssertionError,
   equal,
-} from "https://deno.land/std@v0.41.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 
 import diff, {
   DiffType,
   DiffResult,
-} from "https://deno.land/std@v0.41.0/testing/diff.ts";
+} from "https://deno.land/std@v0.50.0/testing/diff.ts";
 import {
   red,
   green,
   white,
   gray,
   bold,
-} from "https://deno.land/std@v0.41.0/fmt/colors.ts";
+} from "https://deno.land/std@v0.50.0/fmt/colors.ts";
 
 import * as mock from "./mock.ts";
 
@@ -103,10 +103,12 @@ export function toBe(actual: any, expected: any): MatchResult {
   if (actual === expected) return { pass: true };
 
   return buildFail(
-    `expect(${ACTUAL}).toBe(${EXPECTED})\n\n${buildDiffMessage(
-      actual,
-      expected,
-    )}`,
+    `expect(${ACTUAL}).toBe(${EXPECTED})\n\n${
+      buildDiffMessage(
+        actual,
+        expected,
+      )
+    }`,
   );
 }
 
@@ -114,10 +116,12 @@ export function toEqual(actual: any, expected: any): MatchResult {
   if (equal(actual, expected)) return { pass: true };
 
   return buildFail(
-    `expect(${ACTUAL}).toEqual(${EXPECTED})\n\n${buildDiffMessage(
-      actual,
-      expected,
-    )}`,
+    `expect(${ACTUAL}).toEqual(${EXPECTED})\n\n${
+      buildDiffMessage(
+        actual,
+        expected,
+      )
+    }`,
   );
 }
 
@@ -128,9 +132,11 @@ export function toBeGreaterThan(actual: any, comparison: number): MatchResult {
   const comparisonString = createStr(comparison);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeGreaterThan(${EXPECTED})\n\n  ${red(
-      actualString,
-    )} is not greater than ${green(comparisonString)}`,
+    `expect(${ACTUAL}).toBeGreaterThan(${EXPECTED})\n\n  ${
+      red(
+        actualString,
+      )
+    } is not greater than ${green(comparisonString)}`,
   );
 }
 
@@ -141,9 +147,11 @@ export function toBeLessThan(actual: any, comparison: number): MatchResult {
   const comparisonString = createStr(comparison);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeLessThan(${EXPECTED})\n\n  ${red(
-      actualString,
-    )} is not less than ${green(comparisonString)}`,
+    `expect(${ACTUAL}).toBeLessThan(${EXPECTED})\n\n  ${
+      red(
+        actualString,
+      )
+    } is not less than ${green(comparisonString)}`,
   );
 }
 
@@ -157,9 +165,11 @@ export function toBeGreaterThanOrEqual(
   const comparisonString = createStr(comparison);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeGreaterThanOrEqual(${EXPECTED})\n\n  ${red(
-      actualString,
-    )} is not greater than or equal to ${green(comparisonString)}`,
+    `expect(${ACTUAL}).toBeGreaterThanOrEqual(${EXPECTED})\n\n  ${
+      red(
+        actualString,
+      )
+    } is not greater than or equal to ${green(comparisonString)}`,
   );
 }
 
@@ -173,9 +183,11 @@ export function toBeLessThanOrEqual(
   const comparisonString = createStr(comparison);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeLessThanOrEqual(${EXPECTED})\n\n  ${red(
-      actualString,
-    )} is not less than or equal to ${green(comparisonString)}`,
+    `expect(${ACTUAL}).toBeLessThanOrEqual(${EXPECTED})\n\n  ${
+      red(
+        actualString,
+      )
+    } is not less than or equal to ${green(comparisonString)}`,
   );
 }
 
@@ -205,9 +217,11 @@ export function toBeDefined(value: unknown): MatchResult {
   const actualString = createStr(value);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeDefined()\n\n    ${red(
-      actualString,
-    )} is not defined`,
+    `expect(${ACTUAL}).toBeDefined()\n\n    ${
+      red(
+        actualString,
+      )
+    } is not defined`,
   );
 }
 
@@ -217,9 +231,11 @@ export function toBeUndefined(value: unknown): MatchResult {
   const actualString = createStr(value);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeUndefined()\n\n    ${red(
-      actualString,
-    )} is defined but should be undefined`,
+    `expect(${ACTUAL}).toBeUndefined()\n\n    ${
+      red(
+        actualString,
+      )
+    } is defined but should be undefined`,
   );
 }
 
@@ -250,9 +266,11 @@ export function toBeInstanceOf(value: any, expected: Function): MatchResult {
   const expectedString = createStr(expected);
 
   return buildFail(
-    `expect(${ACTUAL}).toBeInstanceOf(${EXPECTED})\n\n    expected ${green(
-      expected.name,
-    )} but received ${red(actualString)}`,
+    `expect(${ACTUAL}).toBeInstanceOf(${EXPECTED})\n\n    expected ${
+      green(
+        expected.name,
+      )
+    } but received ${red(actualString)}`,
   );
 }
 
@@ -265,9 +283,11 @@ export function toMatch(value: any, pattern: RegExp | string): MatchResult {
     const patternString = createStr(pattern);
 
     return buildFail(
-      `expect(${ACTUAL}).toMatch(${EXPECTED})\n\n    expected ${red(
-        actualString,
-      )} to contain ${green(patternString)}`,
+      `expect(${ACTUAL}).toMatch(${EXPECTED})\n\n    expected ${
+        red(
+          actualString,
+        )
+      } to contain ${green(patternString)}`,
     );
   } else if (pattern instanceof RegExp) {
     if (pattern.exec(valueStr)) return { pass: true };
@@ -276,9 +296,11 @@ export function toMatch(value: any, pattern: RegExp | string): MatchResult {
     const patternString = createStr(pattern);
 
     return buildFail(
-      `expect(${ACTUAL}).toMatch(${EXPECTED})\n\n    ${red(
-        actualString,
-      )} did not match regex ${green(patternString)}`,
+      `expect(${ACTUAL}).toMatch(${EXPECTED})\n\n    ${
+        red(
+          actualString,
+        )
+      } did not match regex ${green(patternString)}`,
     );
   } else {
     return buildFail("Invalid internal state");
@@ -294,9 +316,11 @@ export function toHaveProperty(value: any, propName: string): MatchResult {
   const propNameString = createStr(propName);
 
   return buildFail(
-    `expect(${ACTUAL}).toHaveProperty(${EXPECTED})\n\n    ${red(
-      actualString,
-    )} did not contain property ${green(propNameString)}`,
+    `expect(${ACTUAL}).toHaveProperty(${EXPECTED})\n\n    ${
+      red(
+        actualString,
+      )
+    } did not contain property ${green(propNameString)}`,
   );
 }
 export function toHaveLength(value: any, length: number): MatchResult {
@@ -306,9 +330,11 @@ export function toHaveLength(value: any, length: number): MatchResult {
   const lengthString = createStr(length);
 
   return buildFail(
-    `expect(${ACTUAL}).toHaveLength(${EXPECTED})\n\n    expected array to have length ${green(
-      lengthString,
-    )} but was ${red(actualString)}`,
+    `expect(${ACTUAL}).toHaveLength(${EXPECTED})\n\n    expected array to have length ${
+      green(
+        lengthString,
+      )
+    } but was ${red(actualString)}`,
   );
 }
 
@@ -320,15 +346,19 @@ export function toContain(value: any, item: any): MatchResult {
 
   if (Array.isArray(value)) {
     return buildFail(
-      `expect(${ACTUAL}).toContain(${EXPECTED})\n\n    ${red(
-        actualString,
-      )} did not contain ${green(itemString)}`,
+      `expect(${ACTUAL}).toContain(${EXPECTED})\n\n    ${
+        red(
+          actualString,
+        )
+      } did not contain ${green(itemString)}`,
     );
   } else {
     return buildFail(
-      `expect(${ACTUAL}).toContain(${EXPECTED})\n\n    expected ${red(
-        actualString,
-      )} to contain ${green(itemString)} but it is ${red("not")} an array`,
+      `expect(${ACTUAL}).toContain(${EXPECTED})\n\n    expected ${
+        red(
+          actualString,
+        )
+      } to contain ${green(itemString)} but it is ${red("not")} an array`,
     );
   }
 }
@@ -350,21 +380,29 @@ export function toThrow(value: any, error?: RegExp | string): MatchResult {
     if (typeof error === "string") {
       if (!value.message.includes(error)) {
         return buildFail(
-          `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${red(
-            actualString,
-          )} to throw error matching ${green(errorString)} but it threw ${red(
-            value.toString(),
-          )}`,
+          `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${
+            red(
+              actualString,
+            )
+          } to throw error matching ${green(errorString)} but it threw ${
+            red(
+              value.toString(),
+            )
+          }`,
         );
       }
     } else if (error instanceof RegExp) {
       if (!value.message.match(error)) {
         return buildFail(
-          `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${red(
-            actualString,
-          )} to throw error matching ${green(errorString)} but it threw ${red(
-            value.toString(),
-          )}`,
+          `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${
+            red(
+              actualString,
+            )
+          } to throw error matching ${green(errorString)} but it threw ${
+            red(
+              value.toString(),
+            )
+          }`,
         );
       }
     }
@@ -372,9 +410,11 @@ export function toThrow(value: any, error?: RegExp | string): MatchResult {
     return { pass: true };
   } else {
     return buildFail(
-      `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${red(
-        actualString,
-      )} to throw but it did not`,
+      `expect(${ACTUAL}).toThrow(${EXPECTED})\n\nexpected ${
+        red(
+          actualString,
+        )
+      } to throw but it did not`,
     );
   }
 }
@@ -406,9 +446,11 @@ export function toHaveBeenCalled(value: any): MatchResult {
   if (calls && calls.length !== 0) return { pass: true };
 
   return buildFail(
-    `expect(${ACTUAL}).toHaveBeenCalled()\n\n    ${red(
-      actualString,
-    )} was not called`,
+    `expect(${ACTUAL}).toHaveBeenCalled()\n\n    ${
+      red(
+        actualString,
+      )
+    } was not called`,
   );
 }
 
@@ -434,9 +476,11 @@ export function toHaveBeenCalledWith(value: any, ...args: any[]): MatchResult {
   const argsString = createStr(args);
 
   return buildFail(
-    `expect(${ACTUAL}).toHaveBeenCalledTimes(${EXPECTED})\n\n    function was not called with: ${green(
-      argsString,
-    )}`,
+    `expect(${ACTUAL}).toHaveBeenCalledTimes(${EXPECTED})\n\n    function was not called with: ${
+      green(
+        argsString,
+      )
+    }`,
   );
 }
 

--- a/matchers_test.ts
+++ b/matchers_test.ts
@@ -1,8 +1,7 @@
 import {
   assert,
   assertEquals,
-  AssertionError,
-} from "https://deno.land/std@v0.41.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 
 import {
   toBe,
@@ -29,9 +28,9 @@ function assertResult(actual: MatchResult, expected: MatchResult) {
   assertEquals(
     actual.pass,
     expected.pass,
-    `expected to be ${expected.pass
-      ? `pass but received: ${actual.message}`
-      : "fail"}`,
+    `expected to be ${
+      expected.pass ? `pass but received: ${actual.message}` : "fail"
+    }`,
   );
   if (typeof expected.message !== "undefined") {
     assert(!!actual.message, "no message given");
@@ -49,293 +48,402 @@ function assertResultPass(result: any) {
   assertResult(result, { pass: true });
 }
 
-Deno.test(function toBePass() {
-  assertResultPass(toBe(10, 10));
+Deno.test({
+  name: "toBePass",
+  fn: () => {
+    assertResultPass(toBe(10, 10));
+  },
 });
 
-Deno.test(function toBeFail() {
-  assertResult(toBe(10, 20), {
-    pass: false,
-    message: `expect(actual).toBe(expected)\n\n-   10\n+   20`,
-  });
+Deno.test({
+  name: "toBeFail",
+  fn: () => {
+    assertResult(toBe(10, 20), {
+      pass: false,
+      message: `expect(actual).toBe(expected)
+                -   10
+                +   20`,
+    });
 
-  assertResult(toBe({}, {}), {
-    pass: false,
-    message: `expect(actual).toBe(expected)\n\n    {}`,
-  });
+    assertResult(toBe({}, {}), {
+      pass: false,
+      message: `expect(actual).toBe(expected)
+      
+                {}`,
+    });
+  },
 });
 
-Deno.test(function toEqualPass() {
-  assertResultPass(toEqual({ a: 1 }, { a: 1 }));
-  assertResultPass(toEqual(1, 1));
-  assertResultPass(toEqual([1], [1]));
+Deno.test({
+  name: "toEqualPass",
+  fn: () => {
+    assertResultPass(toEqual({ a: 1 }, { a: 1 }));
+    assertResultPass(toEqual(1, 1));
+    assertResultPass(toEqual([1], [1]));
+  },
 });
 
-Deno.test(function toEqualFail() {
-  assertResult(toEqual(10, 20), {
-    pass: false,
-    message: `expect(actual).toEqual(expected)\n\n-   10\n+   20`,
-  });
+Deno.test({
+  name: "toEqualFail",
+  fn: () => {
+    assertResult(toEqual(10, 20), {
+      pass: false,
+      message: `expect(actual).toEqual(expected)\n\n-   10\n+   20`,
+    });
 
-  assertResult(toEqual({ a: 1 }, { a: 2 }), {
-    pass: false,
-    message: `expect(actual).toEqual(expected)
-        -   { a: 1 }
-        +   { a: 2 }`,
-  });
+    assertResult(toEqual({ a: 1 }, { a: 2 }), {
+      pass: false,
+      message: `expect(actual).toEqual(expected)
+                -   { a: 1 }
+                +   { a: 2 }`,
+    });
+  },
 });
 
-Deno.test(function toBeGreaterThanPass() {
-  assertResultPass(toBeGreaterThan(2, 1));
+Deno.test({
+  name: "toBeGreaterThanPass",
+  fn: () => {
+    assertResultPass(toBeGreaterThan(2, 1));
+  },
 });
 
-Deno.test(function toBeGreaterThanFail() {
-  assertResult(toBeGreaterThan(1, 2), {
-    pass: false,
-    message: `expect(actual).toBeGreaterThan(expected)
-
-            1 is not greater than 2`,
-  });
+Deno.test({
+  name: "toBeGreaterThanFail",
+  fn: () => {
+    assertResult(toBeGreaterThan(1, 2), {
+      pass: false,
+      message: `expect(actual).toBeGreaterThan(expected)
+  
+                1 is not greater than 2`,
+    });
+  },
 });
 
-Deno.test(function toBeLessThanPass() {
-  assertResultPass(toBeLessThan(1, 2));
+Deno.test({
+  name: "toBeLessThanPass",
+  fn: () => {
+    assertResultPass(toBeLessThan(1, 2));
+  },
 });
 
-Deno.test(function toBeLessThanFail() {
-  assertResult(toBeLessThan(2, 1), {
-    pass: false,
-    message: `expect(actual).toBeLessThan(expected)
-
-            2 is not less than 1`,
-  });
+Deno.test({
+  name: "toBeLessThanFail",
+  fn: () => {
+    assertResult(toBeLessThan(2, 1), {
+      pass: false,
+      message: `expect(actual).toBeLessThan(expected)
+  
+                2 is not less than 1`,
+    });
+  },
 });
 
-Deno.test(function toBeLessThanOrEqualPass() {
-  assertResultPass(toBeLessThanOrEqual(1, 2));
+Deno.test({
+  name: "toBeLessThanOrEqualPass",
+  fn: () => {
+    assertResultPass(toBeLessThanOrEqual(1, 2));
+  },
 });
 
-Deno.test(function toBeLessThanOrEqualFail() {
-  assertResult(toBeLessThanOrEqual(2, 1), {
-    pass: false,
-    message: `expect(actual).toBeLessThanOrEqual(expected)
-
-            2 is not less than or equal to 1`,
-  });
+Deno.test({
+  name: "toBeLessThanOrEqualFail",
+  fn: () => {
+    assertResult(toBeLessThanOrEqual(2, 1), {
+      pass: false,
+      message: `expect(actual).toBeLessThanOrEqual(expected)
+  
+                2 is not less than or equal to 1`,
+    });
+  },
 });
 
-Deno.test(function toBeTruthyPass() {
-  assertResultPass(toBeTruthy(1));
-  assertResultPass(toBeTruthy(true));
-  assertResultPass(toBeTruthy([]));
+Deno.test({
+  name: "toBeTruthyPass",
+  fn: () => {
+    assertResultPass(toBeTruthy(1));
+    assertResultPass(toBeTruthy(true));
+    assertResultPass(toBeTruthy([]));
+  },
 });
 
-Deno.test(function toBeTruthyFail() {
-  assertResult(toBeTruthy(false), {
-    pass: false,
-    message: `expect(actual).toBeTruthy()
-
-              false is not truthy`,
-  });
+Deno.test({
+  name: "toBeTruthyFail",
+  fn: () => {
+    assertResult(toBeTruthy(false), {
+      pass: false,
+      message: `expect(actual).toBeTruthy()
+  
+                false is not truthy`,
+    });
+  },
 });
 
-Deno.test(function toBeFalsyPass() {
-  assertResultPass(toBeFalsy(0));
-  assertResultPass(toBeFalsy(false));
-  assertResultPass(toBeFalsy(null));
+Deno.test({
+  name: "toBeFalsyPass",
+  fn: () => {
+    assertResultPass(toBeFalsy(0));
+    assertResultPass(toBeFalsy(false));
+    assertResultPass(toBeFalsy(null));
+  },
 });
 
-Deno.test(function toBeFalsyFail() {
-  assertResult(toBeFalsy(true), {
-    pass: false,
-    message: `expect(actual).toBeFalsy()
-
-              true is not falsy`,
-  });
+Deno.test({
+  name: "toBeFalsyFail",
+  fn: () => {
+    assertResult(toBeFalsy(true), {
+      pass: false,
+      message: `expect(actual).toBeFalsy()
+  
+                true is not falsy`,
+    });
+  },
 });
 
-Deno.test(function toBeDefinedPass() {
-  assertResultPass(toBeDefined(1));
-  assertResultPass(toBeDefined({}));
+Deno.test({
+  name: "toBeDefinedPass",
+  fn: () => {
+    assertResultPass(toBeDefined(1));
+    assertResultPass(toBeDefined({}));
+  },
 });
 
-Deno.test(function toBeDefinedFail() {
-  assertResult(toBeDefined(undefined), {
-    pass: false,
-    message: `expect(actual).toBeDefined()
-
-              undefined is not defined`,
-  });
+Deno.test({
+  name: "toBeDefinedFail",
+  fn: () => {
+    assertResult(toBeDefined(undefined), {
+      pass: false,
+      message: `expect(actual).toBeDefined()
+  
+                undefined is not defined`,
+    });
+  },
 });
 
-Deno.test(function toBeUndefinedPass() {
-  assertResultPass(toBeUndefined(undefined));
+Deno.test({
+  name: "toBeUndefinedPass",
+  fn: () => {
+    assertResultPass(toBeUndefined(undefined));
+  },
 });
 
-Deno.test(function toBeUndefinedFail() {
-  assertResult(toBeUndefined(null), {
-    pass: false,
-    message: `expect(actual).toBeUndefined()
-
-              null is defined but should be undefined`,
-  });
+Deno.test({
+  name: "toBeUndefinedFail",
+  fn: () => {
+    assertResult(toBeUndefined(null), {
+      pass: false,
+      message: `expect(actual).toBeUndefined()
+  
+                null is defined but should be undefined`,
+    });
+  },
 });
 
-Deno.test(function toBeNullPass() {
-  assertResultPass(toBeNull(null));
+Deno.test({
+  name: "toBeNullPass",
+  fn: () => {
+    assertResultPass(toBeNull(null));
+  },
 });
 
-Deno.test(function toBeNullFail() {
-  assertResult(toBeNull(10), {
-    pass: false,
-    message: `expect(actual).toBeNull()
-
-              10 should be null`,
-  });
+Deno.test({
+  name: "toBeNullFail",
+  fn: () => {
+    assertResult(toBeNull(10), {
+      pass: false,
+      message: `expect(actual).toBeNull()
+  
+                10 should be null`,
+    });
+  },
 });
 
-Deno.test(function toBeNaNPass() {
-  assertResultPass(toBeNaN(NaN));
+Deno.test({
+  name: "toBeNaNPass",
+  fn: () => {
+    assertResultPass(toBeNaN(NaN));
+  },
 });
 
-Deno.test(function toBeNaNFail() {
-  assertResult(toBeNaN(10), {
-    pass: false,
-    message: `expect(actual).toBeNaN()
-
-              10 should be NaN`,
-  });
+Deno.test({
+  name: "toBeNaNFail",
+  fn: () => {
+    assertResult(toBeNaN(10), {
+      pass: false,
+      message: `expect(actual).toBeNaN()
+  
+                10 should be NaN`,
+    });
+  },
 });
 
-Deno.test(function toBeInstanceOfPass() {
-  class A {}
-  const a = new A();
-  assertResultPass(toBeInstanceOf(a, A));
+Deno.test({
+  name: "toBeInstanceOfPass",
+  fn: () => {
+    class A {}
+    const a = new A();
+    assertResultPass(toBeInstanceOf(a, A));
+  },
 });
 
-Deno.test(function toBeNaNFail() {
-  class A {}
-  class B {}
+Deno.test({
+  name: "toBeInstanceOfFail",
+  fn: () => {
+    class A {}
+    class B {}
 
-  const a = new A();
+    const a = new A();
 
-  assertResult(toBeInstanceOf(a, B), {
-    pass: false,
-    message: `expect(actual).toBeInstanceOf(expected)
+    assertResult(toBeInstanceOf(a, B), {
+      pass: false,
+      message: `expect(actual).toBeInstanceOf(expected)
 
-              expected B but received A {}`,
-  });
+                expected B but received A {}`,
+    });
+  },
 });
 
-Deno.test(function toBeMatchPass() {
-  assertResultPass(toMatch("hello", "hell"));
-  assertResultPass(toMatch("hello", /^hell/));
+Deno.test({
+  name: "toBeMatchPass",
+  fn: () => {
+    assertResultPass(toMatch("hello", "hell"));
+    assertResultPass(toMatch("hello", /^hell/));
+  },
 });
 
-Deno.test(function toBeMatchFail() {
-  assertResult(toMatch("yo", "hell"), {
-    pass: false,
-    message: `expect(actual).toMatch(expected)
+Deno.test({
+  name: "toBeMatchFail",
+  fn: () => {
+    assertResult(toMatch("yo", "hell"), {
+      pass: false,
+      message: `expect(actual).toMatch(expected)
+  
+                expected yo to contain hell`,
+    });
 
-              expected yo to contain hell`,
-  });
+    assertResult(toMatch("yo", /^hell/), {
+      pass: false,
+      message: `expect(actual).toMatch(expected)
 
-  assertResult(toMatch("yo", /^hell/), {
-    pass: false,
-    message: `expect(actual).toMatch(expected)
-
-              yo did not match regex /^hell/`,
-  });
+                yo did not match regex /^hell/`,
+    });
+  },
 });
 
-Deno.test(function toBeHavePropertyPass() {
-  assertResultPass(toHaveProperty({ a: 1 }, "a"));
+Deno.test({
+  name: "toBeHavePropertyPass",
+  fn: () => {
+    assertResultPass(toHaveProperty({ a: 1 }, "a"));
+  },
 });
 
-Deno.test(function toBeHavePropertyFail() {
-  assertResult(toHaveProperty({ a: 1 }, "b"), {
-    pass: false,
-    message:
-      `expect(actual).toHaveProperty(expected)\n\n    { a: 1 } did not contain property b`,
-  });
+Deno.test({
+  name: "toBeHavePropertyFail",
+  fn: () => {
+    assertResult(toHaveProperty({ a: 1 }, "b"), {
+      pass: false,
+      message: `expect(actual).toHaveProperty(expected)
+      
+                { a: 1 } did not contain property b`,
+    });
+  },
 });
 
-Deno.test(function toHaveLengthPass() {
-  assertResultPass(toHaveLength([], 0));
-  assertResultPass(toHaveLength([1, 2], 2));
-  assertResultPass(toHaveLength({ length: 2 }, 2));
+Deno.test({
+  name: "toHaveLengthPass",
+  fn: () => {
+    assertResultPass(toHaveLength([], 0));
+    assertResultPass(toHaveLength([1, 2], 2));
+    assertResultPass(toHaveLength({ length: 2 }, 2));
+  },
 });
 
-Deno.test(function toBeHaveLengthFail() {
-  assertResult(toHaveLength([], 1), {
-    pass: false,
-    message:
-      `expect(actual).toHaveLength(expected)\n\n    expected array to have length 1 but was 0`,
-  });
+Deno.test({
+  name: "toBeHaveLengthFail",
+  fn: () => {
+    assertResult(toHaveLength([], 1), {
+      pass: false,
+      message: `expect(actual).toHaveLength(expected)
+        
+                expected array to have length 1 but was 0`,
+    });
+  },
 });
 
-Deno.test(function toContainPass() {
-  assertResultPass(toContain([1, 2], 2));
+Deno.test({
+  name: "toContainPass",
+  fn: () => {
+    assertResultPass(toContain([1, 2], 2));
+  },
 });
 
-Deno.test(function toContainFail() {
-  assertResult(toContain([2, 3], 1), {
-    pass: false,
-    message: `expect(actual).toContain(expected)
-    
-    [ 2, 3 ] did not contain 1`,
-  });
-  assertResult(toContain(false, 1), {
-    pass: false,
-    message: `expect(actual).toContain(expected)
-        expected false to contain 1 but it is not an array`,
-  });
+Deno.test({
+  name: "toContainFail",
+  fn: () => {
+    assertResult(toContain([2, 3], 1), {
+      pass: false,
+      message: `expect(actual).toContain(expected)
+      
+                [ 2, 3 ] did not contain 1`,
+    });
+    assertResult(toContain(false, 1), {
+      pass: false,
+      message: `expect(actual).toContain(expected)
+      
+                expected false to contain 1 but it is not an array`,
+    });
+  },
 });
 
-Deno.test(function toThrowPass() {
-  assertResultPass(
-    toThrow(() => {
-      throw new Error("TEST");
-    }, "TEST"),
-  );
-  assertResultPass(
-    toThrow(() => {
-      throw new Error("TEST");
-    }, /^TEST/),
-  );
+Deno.test({
+  name: "toThrowPass",
+  fn: () => {
+    assertResultPass(
+      toThrow(() => {
+        throw new Error("TEST");
+      }, "TEST"),
+    );
+    assertResultPass(
+      toThrow(() => {
+        throw new Error("TEST");
+      }, /^TEST/),
+    );
+  },
 });
 
-Deno.test(function toThrowFail() {
-  assertResult(toThrow(() => {}, "TEST"), {
-    pass: false,
-    message: `expect(actual).toThrow(expected)
-    
-    expected [Function] to throw but it did not`,
-  });
-
-  assertResult(
-    toThrow(() => {
-      throw new Error("BLAH");
-    }, "TEST"),
-    {
+Deno.test({
+  name: "toThrowFail",
+  fn: () => {
+    assertResult(toThrow(() => {}, "TEST"), {
       pass: false,
       message: `expect(actual).toThrow(expected)
-    
-    expected [Function] to throw error matching TEST but it threw Error: BLAH`,
-    },
-  );
+      
+                expected [Function] to throw but it did not`,
+    });
 
-  assertResult(
-    toThrow(() => {
-      throw new Error("BLAH");
-    }, /^TEST/),
-    {
-      pass: false,
-      message: `expect(actual).toThrow(expected)
-    
-    expected [Function] to throw error matching /^TEST/ but it threw Error: BLAH`,
-    },
-  );
+    assertResult(
+      toThrow(() => {
+        throw new Error("BLAH");
+      }, "TEST"),
+      {
+        pass: false,
+        message: `expect(actual).toThrow(expected)
+      
+                  expected [Function] to throw error matching TEST but it threw Error: BLAH`,
+      },
+    );
+
+    assertResult(
+      toThrow(() => {
+        throw new Error("BLAH");
+      }, /^TEST/),
+      {
+        pass: false,
+        message: `expect(actual).toThrow(expected)
+      
+                  expected [Function] to throw error matching /^TEST/ but it threw Error: BLAH`,
+      },
+    );
+  },
 });
 
 //TODO(allain) - toHaveBeenCalled(value: any): MatchResult

--- a/mock_test.ts
+++ b/mock_test.ts
@@ -1,62 +1,72 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@v0.41.0/testing/asserts.ts";
+} from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 
 import * as mock from "./mock.ts";
 
-Deno.test(function canMockFunctions() {
-  assertEquals(typeof mock.fn(), "function");
-  const f = mock.fn();
-  f(10);
-  f(20);
+Deno.test({
+  name: "canMockFunctions",
+  fn: () => {
+    assertEquals(typeof mock.fn(), "function");
+    const f = mock.fn();
+    f(10);
+    f(20);
 
-  const calls = mock.calls(f);
-  assert(Array.isArray(calls));
-  assertEquals(calls.length, 2);
-  assertEquals(calls.map((c: any) => c.args), [[10], [20]]);
-  assertEquals(calls.map((c: any) => c.returned), [undefined, undefined]);
+    const calls = mock.calls(f);
+    assert(Array.isArray(calls));
+    assertEquals(calls.length, 2);
+    assertEquals(calls.map((c: any) => c.args), [[10], [20]]);
+    assertEquals(calls.map((c: any) => c.returned), [undefined, undefined]);
 
-  assert(
-    calls.map((c: any) => typeof c.timestamp).every((t: string) =>
-      t === "number"
-    ),
-  );
+    assert(
+      calls.map((c: any) => typeof c.timestamp).every((t: string) =>
+        t === "number"
+      ),
+    );
+  },
 });
 
-Deno.test(function mockFunctionTracksReturns() {
-  const f = mock.fn(
-    () => 1,
-    () => {
-      throw new Error("TEST");
-    },
-  );
-  try {
-    f();
-    f();
-  } catch {}
-  const calls = mock.calls(f);
-  assert(calls[0].returns);
-  assert(!calls[0].throws);
-  assert(!calls[1].returns);
-  assert(calls[1].throws);
+Deno.test({
+  name: "mockFunctionTracksReturns",
+  fn: () => {
+    const f = mock.fn(
+      () => 1,
+      () => {
+        throw new Error("TEST");
+      },
+    );
+    try {
+      f();
+      f();
+    } catch {}
+    const calls = mock.calls(f);
+    assert(calls[0].returns);
+    assert(!calls[0].throws);
+    assert(!calls[1].returns);
+    assert(calls[1].throws);
+  },
 });
-Deno.test(function mockFunctionCanHaveImplementations() {
-  const f = mock.fn(
-    (n: number) => n,
-    (n: number) => n * 2,
-    (n: number) => n * 3,
-  );
-  f(1);
-  f(1);
-  f(1);
-  f(1);
-  f(1);
 
-  const calls = mock.calls(f);
-  assertEquals(calls.length, 5);
-  assertEquals(
-    calls.map((c: mock.MockCall) => c.returned),
-    [1, 2, 3, undefined, undefined],
-  );
+Deno.test({
+  name: "mockFunctionCanHaveImplementations",
+  fn: () => {
+    const f = mock.fn(
+      (n: number) => n,
+      (n: number) => n * 2,
+      (n: number) => n * 3,
+    );
+    f(1);
+    f(1);
+    f(1);
+    f(1);
+    f(1);
+
+    const calls = mock.calls(f);
+    assertEquals(calls.length, 5);
+    assertEquals(
+      calls.map((c: mock.MockCall) => c.returned),
+      [1, 2, 3, undefined, undefined],
+    );
+  },
 });


### PR DESCRIPTION
This PR upgrades from `std@v0.41.0` to `std@v0.50.0`, which works on Deno `1.0.0-rc1`. The interface of the tests have changed, it also fixes that.

Fixes #3 