### PR TITLE
Fix error due to enable of `importsNotUsedAsValues`

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -1,5 +1,5 @@
 import * as builtInMatchers from "./matchers.ts";
-import { Matcher, Matchers } from "./matchers.ts";
+import type { Matcher, Matchers } from "./matchers.ts";
 
 import { AssertionError } from "https://deno.land/std@v0.50.0/testing/asserts.ts";
 


### PR DESCRIPTION
Fix the following error due to Deno v1.4.0
error: TS1371 [ERROR]: This import is never used as a value and must use 'import type' because the 'importsNotUsedAsValues' is set to 'error'.
import { Matcher, Matchers } from "./matchers.ts";