### PR TITLE
chore: bump deps

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -1,7 +1,7 @@
 import * as builtInMatchers from "./matchers.ts";
 import type { Matcher, Matchers } from "./matchers.ts";
 
-import { AssertionError } from "https://deno.land/std@0.50.0/testing/asserts.ts";
+import { AssertionError } from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
 interface Expected {
   toBe(candidate: any): void;

--- a/expect_test.ts
+++ b/expect_test.ts
@@ -2,7 +2,7 @@ import {
   assertEquals,
   AssertionError,
   assertThrows,
-} from "https://deno.land/std@0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
 import { addMatchers, expect } from "./expect.ts";
 import * as mock from "./mock.ts";

--- a/matchers.ts
+++ b/matchers.ts
@@ -1,19 +1,19 @@
 import {
   AssertionError,
   equal,
-} from "https://deno.land/std@0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
 import diff, {
   DiffResult,
   DiffType,
-} from "https://deno.land/std@0.50.0/testing/diff.ts";
+} from "https://deno.land/std@0.97.0/testing/diff.ts";
 import {
   bold,
   gray,
   green,
   red,
   white,
-} from "https://deno.land/std@0.50.0/fmt/colors.ts";
+} from "https://deno.land/std@0.97.0/fmt/colors.ts";
 
 import * as mock from "./mock.ts";
 

--- a/matchers_test.ts
+++ b/matchers_test.ts
@@ -1,7 +1,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@0.97.0/testing/asserts.ts";
 import * as mock from "./mock.ts";
 
 import {

--- a/mock_test.ts
+++ b/mock_test.ts
@@ -1,7 +1,7 @@
 import {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.50.0/testing/asserts.ts";
+} from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
 import * as mock from "./mock.ts";
 


### PR DESCRIPTION
Bump dependencies (most importantly `std`) to avoid errors and conflicts in newer Deno versions