### PR TITLE
Type `resolves/rejects` so that LSP recognizes it as awaitable.

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -3,7 +3,7 @@ import type { Matcher, Matchers } from "./matchers.ts";
 
 import { AssertionError } from "https://deno.land/std@0.97.0/testing/asserts.ts";
 
-interface Expected {
+export interface Expected {
   toBe(candidate: any): void;
   toEqual(candidate: any): void;
   toBeTruthy(): void;
@@ -34,8 +34,8 @@ interface Expected {
   toHaveNthReturnedWith(nthCall: number, value: any): void;
 
   not: Expected;
-  resolves: Expected;
-  rejects: Expected;
+  resolves: Async<Expected>;
+  rejects: Async<Expected>;
 }
 
 const matchers: Record<any, Matcher> = {
@@ -113,6 +113,15 @@ export function expect(value: any): Expected {
   );
 
   return self;
+}
+
+// a helper type to match any function. Used so that we only convert functions
+// to return a promise and not properties.
+type Fn = (...args: any[]) => any;
+
+// converts all the menthods in an interface to be async functions
+export type Async<T> = {
+  [K in keyof T]: T[K] extends Fn ? (...args: Parameters<T[K]>) => Promise<ReturnType<T[K]>> : T[K];
 }
 
 export function addMatchers(newMatchers: Matchers): void {


### PR DESCRIPTION
> fixes #23 
Once you use `Expected#resolves` or `#Expected.rejects`, the matcher functions return a `Promise<void>` and not a `void`. However, the types do not reflect this and so the language server incorrectly warns that the 'await' has no effect on the expression.

This maps over the `Expected` type so that if the `resolves` and `rejects` properties point to a "Promisified" version of `Expected` where each matcher function function return `Promise<void>` instead of `void`.