### PR TITLE
✨Add specific property value match to `toHaveProperty()`

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -14,7 +14,7 @@ export interface Expected {
   toBeNull(): void;
   toBeNaN(): void;
   toMatch(pattern: RegExp | string): void;
-  toHaveProperty(propName: string): void;
+  toHaveProperty(propName: string, propValue?: any): void;
   toHaveLength(length: number): void;
   toContain(item: any): void;
   toThrow(error?: RegExp | string): void;

--- a/expect_test.ts
+++ b/expect_test.ts
@@ -356,9 +356,15 @@ Deno.test({
 Deno.test({
   name: "toHaveProperty",
   fn: async () => {
-    await assertAllPass(() => expect({ a: "10" }).toHaveProperty("a"));
+    await assertAllPass(
+      () => expect({ a: "10" }).toHaveProperty("a"),
+      () => expect({ a: "10" }).toHaveProperty("a", "10"),
+    );
 
-    await assertAllFail(() => expect({ a: 1 }).toHaveProperty("b"));
+    await assertAllFail(
+      () => expect({ a: 1 }).toHaveProperty("b"),
+      () => expect({ a: 1 }).toHaveProperty("a", 2),
+    );
   },
 });
 

--- a/matchers.ts
+++ b/matchers.ts
@@ -285,8 +285,11 @@ export function toMatch(value: any, pattern: RegExp | string): MatchResult {
   }
 }
 
-export function toHaveProperty(value: any, propName: string): MatchResult {
+export function toHaveProperty(value: any, propName: string, propValue?: any): MatchResult {
   if (typeof value === 'object' && typeof value[propName] !== 'undefined') {
+    if (typeof propValue !== 'undefined') {
+      return toHavePropertyWithValue(value, propName, propValue);
+    }
     return { pass: true }
   }
 
@@ -299,6 +302,23 @@ export function toHaveProperty(value: any, propName: string): MatchResult {
     )} did not contain property ${green(propNameString)}`
   )
 }
+
+function toHavePropertyWithValue(value: any, propName: string, propValue: any): MatchResult {
+  const propValueString = createStr(propValue);
+  const propNameString = createStr(propName);
+  const actualString = createStr(value[propName]);
+
+  if (typeof value === 'object' && equal(value[propName], propValue)) {
+    return { pass: true };
+  }
+
+  const VALUE = green(bold('value'));
+
+  return buildFail(
+    `expect(${ACTUAL}).toHaveProperty(${EXPECTED}, ${VALUE})\n\n    expected property ${green(propNameString)} to equal ${green(propValueString)} but was ${red(actualString)}`
+  );
+}
+
 export function toHaveLength(value: any, length: number): MatchResult {
   if (value?.length === length) return { pass: true }
 


### PR DESCRIPTION
Sometimes you want to test not only that a property exists, but that it also has a particular value. For example:

```js
let state = getState();
expect(state).toHaveProperty('type', 'ok');
```

This adds an optional `propertyValue` parameter to the `toHaveProperty()` matcher that will be used to compare against and fail if it does not match. In the event that this parameter is not present, the matcher will behave as before.