### PR TITLE
Adds toBeCloseTo matcher with associated tests

### DIFF
--- a/expect.ts
+++ b/expect.ts
@@ -6,6 +6,7 @@ import { AssertionError } from "https://deno.land/std@0.97.0/testing/asserts.ts"
 export interface Expected {
   toBe(candidate: any): void;
   toEqual(candidate: any): void;
+  toBeCloseTo(candidate: number, precision?: number): void;
   toBeTruthy(): void;
   toBeFalsy(): void;
   toBeDefined(): void;

--- a/expect_test.ts
+++ b/expect_test.ts
@@ -354,6 +354,21 @@ Deno.test({
 });
 
 Deno.test({
+  name: 'toBeClose',
+  fn: async () => {
+    await assertAllPass(
+      () => expect(0.2 + 0.1).toBeCloseTo(0.3),
+      () => expect(0.2 + 0.1).toBeCloseTo(0.3, 5)
+    )
+
+    await assertAllFail(
+      () => expect(1.01 + 0.22).toBeCloseTo(1.2249999),
+      () => expect(3.141592e-7).toBeCloseTo(3e-7, 8)
+    )
+  }
+})
+
+Deno.test({
   name: "toHaveProperty",
   fn: async () => {
     await assertAllPass(

--- a/matchers.ts
+++ b/matchers.ts
@@ -256,6 +256,38 @@ export function toBeInstanceOf(value: any, expected: Function): MatchResult {
   )
 }
 
+export function toBeCloseTo(
+  actual: number,
+  expected: number,
+  precision = 2
+): MatchResult {
+  // const secondArgument = arguments.length === 3 ? 'precision' : undefined;
+
+  let pass = false
+  let expectedDiff = 0
+  let actualDiff = 0
+
+  if (actual === Infinity && expected === Infinity) {
+    pass = true // Infinity - Infinity is NaN
+  } else if (actual === -Infinity && expected === -Infinity) {
+    pass = true // -Infinity - -Infinity is NaN
+  } else {
+    expectedDiff = Math.pow(10, -precision) / 2
+    actualDiff = Math.abs(expected - actual)
+    pass = actualDiff < expectedDiff
+  }
+
+  if (pass) return { pass: true }
+  else {
+    return buildFail(
+      `expect(${ACTUAL}).toBeCloseTo(${EXPECTED}, ${precision})\n\n${buildDiffMessage(
+        actual,
+        expected
+      )}`
+    )
+  }
+}
+
 export function toMatch(value: any, pattern: RegExp | string): MatchResult {
   const valueStr = value.toString()
   if (typeof pattern === 'string') {

--- a/matchers_test.ts
+++ b/matchers_test.ts
@@ -7,6 +7,7 @@ import * as mock from './mock.ts'
 import {
   MatchResult,
   toBe,
+  toBeCloseTo,
   toBeDefined,
   toBeFalsy,
   toBeGreaterThan,
@@ -377,6 +378,82 @@ Deno.test({
 
                 expected array to have length 1 but was 0`
     })
+  }
+})
+
+Deno.test({
+  name: 'toBeCloseToPass',
+  fn: () => {
+    ;[
+      [0, 0],
+      [0, 0.001],
+      [1.23, 1.229],
+      [1.23, 1.226],
+      [1.23, 1.225],
+      [1.23, 1.234],
+      [Infinity, Infinity],
+      [-Infinity, -Infinity],
+      [0, 0.1, 0],
+      [0, 0.0001, 3],
+      [0, 0.000004, 5],
+      [2.0000002, 2, 5]
+    ].forEach(([n1, n2, p]) => {
+      assertResultPass(toBeCloseTo(n1, n2, p))
+    })
+  }
+})
+
+Deno.test({
+  name: 'toBeCloseToFail',
+  fn: () => {
+    assertResult(toBeCloseTo(0, 0.01), {
+      pass: false,
+      message: `expect(actual).toBeCloseTo(expected, 2)
+                    -   0
+                    +   0.01`
+    }),
+      assertResult(toBeCloseTo(1, 1.23), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 2)
+                        -   1
+                        +   1.23`
+      }),
+      assertResult(toBeCloseTo(1.23, 1.2249999), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 2)
+                        -   1.23
+                        +   1.2249999`
+      }),
+      assertResult(toBeCloseTo(Infinity, -Infinity), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 2)
+                        -   Infinity
+                        +   -Infinity`
+      }),
+      assertResult(toBeCloseTo(Infinity, 1.23), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 2)
+                        -   Infinity
+                        +   1.23`
+      }),
+      assertResult(toBeCloseTo(-Infinity, -1.23), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 2)
+                        -   -Infinity
+                        +   -1.23`
+      }),
+      assertResult(toBeCloseTo(3.141592e-7, 3e-7, 8), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, 8)
+                        -   3.141592e-7
+                        +   3e-7`
+      }),
+      assertResult(toBeCloseTo(56789, 51234, -4), {
+        pass: false,
+        message: `expect(actual).toBeCloseTo(expected, -4)
+                        -   56789
+                        +   51234`
+      })
   }
 })
 


### PR DESCRIPTION
Note: is as close to the Jest version as I could make it, but I had difficulty implementing some of the test cases, particularly those that threw Matcher errors, or used the rejects / resolves method.
(https://github.com/facebook/jest/blob/94b73a2dd8bf8f6225769f2fe4a9322ac85483d8/packages/expect/src/__tests__/matchers.test.js) line 1692 through 1744 I'm not sure what the analogous version is for this library